### PR TITLE
Include Word counter to the message input

### DIFF
--- a/app/views/amplifiers/_form_conversation.html.erb
+++ b/app/views/amplifiers/_form_conversation.html.erb
@@ -2,10 +2,37 @@
   <%= form_for [amplifier, conversation], url: create_conversation_amplifiers_path, method: :post, remote: true, data: { turbo: :true, controller: "reset-form", action: "turbo:submit-end->reset-form#reset"  } do |f| %>
     <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
     <%= f.label :content, "Message" %>
-    <%= f.text_area :content, class: "form-control", rows: 3, id: "message_content", value: defined?(message) ? message : "" %>
+    <%= f.text_area :content, class: "form-control", rows: 3, id: "message_content", value: defined?(message) ? message : "", oninput: "wordCounter()" %>
+    <div class="d-flex justify-content-between mt-2">
+      <%= f.submit "Send", class: "btn btn-primary" %>
+      <span id="word_counter">200 words remaining</span>
+    </div>
     <%= f.hidden_field :user_id, value: current_user.id %>
     <%= f.hidden_field :amplifier_id, value: amplifier.id %>
     <%= f.hidden_field :conversation_id, value: conversation.id %>
-    <%= f.submit "Send", class: "btn btn-primary mt-2" %>
   <% end %>
 </div>
+
+<script>
+  function wordCounter() {
+    const maxLength = 200;
+    const messageContent = document.getElementById("message_content");
+    const wordCounterElement = document.getElementById("word_counter");
+    const submitButton = document.querySelector("input[type='submit']");
+    const words = messageContent.value.trim().split(/\s+/);
+    const wordCount = words.length === 1 && words[0] === "" ? 0 : words.length;
+
+    const remainingWords = maxLength - wordCount;
+    wordCounterElement.textContent = `${remainingWords} words remaining`;
+
+    if (remainingWords <= 0) {
+      const allowedWords = words.slice(0, maxLength).join(" ");
+      messageContent.value = allowedWords;
+      submitButton.disabled = true;
+      wordCounterElement.style.color = "red";
+    } else {
+      submitButton.disabled = false;
+      wordCounterElement.style.color = "";
+    }
+  }
+</script>


### PR DESCRIPTION
 Count the words in the textarea and update the remaining word count accordingly. It will also prevent users from typing more than 200 words.

![Screen Shot 2023-03-29 at 12 01 13 AM](https://user-images.githubusercontent.com/12284596/228440630-bafdddce-dea7-4659-a968-2cb57be5ac64.png)
![Screen Shot 2023-03-29 at 12 01 49 AM](https://user-images.githubusercontent.com/12284596/228440634-47faadf0-6c2c-455d-8b7e-dac83e8e96b1.png)
